### PR TITLE
Rework monitors processing for desktop manager.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,10 @@
+Changes on 1.4.0 since 1.3.2:
+
+* Reworked monitors processing for desktop manager. Monitor should remember
+    where it's plugged into config. When monitor is getting plugged off then
+    plugged on again, it will get remembered config back.
+
+
 Changes on 1.3.2 since 1.3.1:
 
 * Fixed case when some keyboard shortcuts stopped working: Alt+Home, Alt+Up.

--- a/src/app-config.c
+++ b/src/app-config.c
@@ -2,7 +2,7 @@
  *      app-config.c
  *
  *      Copyright 2010 PCMan <pcman.tw@gmail.com>
- *      Copyright 2012-2014 Andriy Grytsenko (LStranger) <andrej@rep.kiev.ua>
+ *      Copyright 2012-2021 Andriy Grytsenko (LStranger) <andrej@rep.kiev.ua>
  *
  *      This program is free software; you can redistribute it and/or modify
  *      it under the terms of the GNU General Public License as published by
@@ -643,6 +643,11 @@ void fm_app_config_load_desktop_config(GKeyFile *kf, const char *group, FmDeskto
     g_free(cfg->folder);
     cfg->folder = g_key_file_get_string(kf, group, "folder", NULL);
 
+    g_free(cfg->plug_name);
+    cfg->plug_name = g_key_file_get_string(kf, group, "plug_name", NULL);
+    g_free(cfg->model);
+    cfg->model = g_key_file_get_string(kf, group, "model", NULL);
+
     fm_key_file_get_bool(kf, group, "show_wm_menu", &cfg->show_wm_menu);
     _parse_sort(kf, group, &cfg->desktop_sort_type, &cfg->desktop_sort_by);
 #if FM_CHECK_VERSION(1, 2, 0)
@@ -1063,6 +1068,10 @@ void fm_app_config_save_desktop_config(GString *buf, const char *group, FmDeskto
         g_string_append_printf(buf, "desktop_font=%s\n", cfg->desktop_font);
     if(cfg->folder)
         g_string_append_printf(buf, "folder=%s\n", cfg->folder);
+    if(cfg->plug_name)
+        g_string_append_printf(buf, "plug_name=%s\n", cfg->plug_name);
+    if(cfg->model)
+        g_string_append_printf(buf, "model=%s\n", cfg->model);
     g_string_append_printf(buf, "show_wm_menu=%d\n", cfg->show_wm_menu);
     _save_sort(buf, cfg->desktop_sort_type, cfg->desktop_sort_by);
 #if FM_CHECK_VERSION(1, 2, 0)

--- a/src/app-config.h
+++ b/src/app-config.h
@@ -2,7 +2,7 @@
  *      app-config.h
  *
  *      Copyright 2010 - 2011 PCMan <pcman.tw@gmail.com>
- *      Copyright 2012-2014 Andriy Grytsenko (LStranger) <andrej@rep.kiev.ua>
+ *      Copyright 2012-2021 Andriy Grytsenko (LStranger) <andrej@rep.kiev.ua>
  *
  *      This program is free software; you can redistribute it and/or modify
  *      it under the terms of the GNU General Public License as published by
@@ -68,6 +68,7 @@ typedef struct _FmAppConfigClass        FmAppConfigClass;
 
 typedef struct
 {
+    struct _FmDesktop* desktop; /* where it is used */
     FmWallpaperMode wallpaper_mode;
     char* wallpaper;
     char** wallpapers;
@@ -80,6 +81,8 @@ typedef struct
     GdkColor desktop_shadow;
     char* desktop_font;
     char *folder; /* NULL if default, empty if no icons, else path */
+    char* plug_name;
+    char* model; /* only available in GTK+3 */
     gboolean show_wm_menu;
 #if FM_CHECK_VERSION(1, 0, 2)
     FmSortMode desktop_sort_type;

--- a/src/desktop.h
+++ b/src/desktop.h
@@ -2,7 +2,7 @@
  *      desktop.h
  *
  *      Copyright 2010 - 2012 Hong Jen Yee (PCMan) <pcman.tw@gmail.com>
- *      Copyright 2012-2013 Andriy Grytsenko (LStranger) <andrej@rep.kiev.ua>
+ *      Copyright 2012-2021 Andriy Grytsenko (LStranger) <andrej@rep.kiev.ua>
  *
  *      This program is free software; you can redistribute it and/or modify
  *      it under the terms of the GNU General Public License as published by
@@ -84,6 +84,10 @@ struct _FmDesktop
     FmFolderModel* model;
     guint cur_desktop;
     gint monitor;
+    char* plug_name;
+#if GTK_CHECK_VERSION(3, 22, 0)
+    char* mon_model;
+#endif
     FmBackgroundCache *cache;
 #if GTK_CHECK_VERSION(3, 0, 0)
     GtkCssProvider *css;
@@ -95,7 +99,7 @@ struct _FmDesktop
     guint search_entry_changed_id;
     guint search_timeout_id;
     /* desktop settings for this monitor */
-    FmDesktopConfig conf;
+    FmDesktopConfig *conf;
 };
 
 struct _FmDesktopClass

--- a/src/pcmanfm.c
+++ b/src/pcmanfm.c
@@ -394,14 +394,14 @@ gboolean pcmanfm_run(gint screen_num)
                 /* Make sure this is a support image file. */
                 if(gdk_pixbuf_get_file_info(set_wallpaper, NULL, NULL))
                 {
-                    if(desktop->conf.wallpaper)
-                        g_free(desktop->conf.wallpaper);
-                    desktop->conf.wallpaper = set_wallpaper;
+                    if(desktop->conf->wallpaper)
+                        g_free(desktop->conf->wallpaper);
+                    desktop->conf->wallpaper = set_wallpaper;
                     if(! wallpaper_mode) /* if wallpaper mode is not specified */
                     {
                         /* do not use solid color mode; otherwise wallpaper won't be shown. */
-                        if(desktop->conf.wallpaper_mode == FM_WP_COLOR)
-                            desktop->conf.wallpaper_mode = FM_WP_FIT;
+                        if(desktop->conf->wallpaper_mode == FM_WP_COLOR)
+                            desktop->conf->wallpaper_mode = FM_WP_FIT;
                     }
                     wallpaper_changed = TRUE;
                     set_wallpaper = NULL;
@@ -413,9 +413,9 @@ gboolean pcmanfm_run(gint screen_num)
                 FmWallpaperMode mode = fm_app_wallpaper_get_mode_by_name(wallpaper_mode);
 
                 if (mode != (FmWallpaperMode)-1
-                    && mode != desktop->conf.wallpaper_mode)
+                    && mode != desktop->conf->wallpaper_mode)
                 {
-                    desktop->conf.wallpaper_mode = mode;
+                    desktop->conf->wallpaper_mode = mode;
                     wallpaper_changed = TRUE;
                 }
             }


### PR DESCRIPTION
It should not enumerate them but remember plugs instead and associate config with them. When monitor is getting plugged off then plugged on, it will get remembered config back.